### PR TITLE
Investigate build failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: No pnpm project detected, skip build
+        if: ${{ hashFiles('**/pnpm-lock.yaml') == '' }}
+        run: echo "No pnpm lockfile found. Skipping install/build/lint/test steps."
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
@@ -20,6 +24,7 @@ jobs:
           run_install: false
 
       - name: Setup Node.js
+        if: ${{ hashFiles('**/pnpm-lock.yaml') != '' }}
         uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -28,19 +33,24 @@ jobs:
             **/pnpm-lock.yaml
 
       - name: Install dependencies
+        if: ${{ hashFiles('**/pnpm-lock.yaml') != '' }}
         run: pnpm install --frozen-lockfile
 
       - name: Build
+        if: ${{ hashFiles('**/pnpm-lock.yaml') != '' }}
         run: pnpm run build
 
       - name: Typecheck
+        if: ${{ hashFiles('**/pnpm-lock.yaml') != '' }}
         run: pnpm run typecheck
         continue-on-error: true
 
       - name: Lint
+        if: ${{ hashFiles('**/pnpm-lock.yaml') != '' }}
         run: pnpm run lint
         continue-on-error: true
 
       - name: Test
+        if: ${{ hashFiles('**/pnpm-lock.yaml') != '' }}
         run: pnpm run test --if-present
         continue-on-error: true


### PR DESCRIPTION
Update CI workflow to skip Node/pnpm steps if no `pnpm-lock.yaml` is present, preventing build failures in non-Node repositories.

Previously, the CI workflow would attempt Node/pnpm related actions (like cache path resolution) even in repositories without a `pnpm-lock.yaml` file, leading to errors and failed builds. This change ensures these steps are only executed when a pnpm project is detected.

---
<a href="https://cursor.com/background-agent?bcId=bc-a78f47de-948d-4458-b604-567d1ab3bf64">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a78f47de-948d-4458-b604-567d1ab3bf64">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

